### PR TITLE
Update with results from 2021-03-04-raspios-buster-armhf-lite.img

### DIFF
--- a/index.md
+++ b/index.md
@@ -112,6 +112,7 @@ esac
 copy_exec /sbin/resize2fs /sbin
 copy_exec /sbin/fdisk /sbin
 copy_exec /sbin/cryptsetup /sbin
+copy_file binary /lib/arm-linux-gnueabihf/libgcc_s.so.1
 ```
 The programs are ‘resize2fs’, ‘fdisk’ and ‘cryptsetup’.
 The file should be made executable:
@@ -183,6 +184,7 @@ it should be changed to:
 ```
 /dev/mapper/sdcard
 ```
+If the ‘/boot’ partition is specified as “PARTUUID=xxxxx”, that also needs to be changed to a device path.  For Raspberry Pi this is usually ‘/dev/mmcblk0p1’.
 
 **File: etc/crypttab**
 
@@ -234,7 +236,7 @@ time dd bs=4k count=XXXXX if=/dev/sda | sha1sum
 ```
 Assuming that the checksums are correct, now it is time to encrypt the root filesystem of the SD Card, to create the LUKS volume using ‘cryptsetup’. There are many parameters and possible values for the encryption. This is the command I have chosen:
 ```
-cryptsetup --type luks2 --cipher xchacha20,aes-adiantum-plain64 --hash sha256 --iter-time 5000 –keysize 256 --pbkdf argon2i luksFormat /dev/mmcblk0p2
+cryptsetup --type luks2 --cipher xchacha20,aes-adiantum-plain64 --hash sha256 --iter-time 5000 –-key-size 256 --pbkdf argon2i luksFormat /dev/mmcblk0p2
 ```
 More information about the parameters can be found here:
 <https://man7.org/linux/man-pages/man8/cryptsetup.8.html>


### PR DESCRIPTION
I found several problems using this recent buster image:

- cryptsetup failed to set up the partition due to libgcc_s.so.1.  It seems copy_exec misses this library since it's optional.
- the /boot partition in fstab cannot be specified as a partition UUID, otherwise it locks the console
- the --key-size argument seems to have a typo